### PR TITLE
Enable selection of database file from application backup

### DIFF
--- a/src/prefs.rs
+++ b/src/prefs.rs
@@ -4,10 +4,10 @@ use jaded::{AnnotationIter, ConversionResult, FromJava};
 #[derive(Debug, FromJava)]
 struct EncryptionSettings {
     #[jaded(extract(extract_sf3))]
-    /// sf1 holds the salt of PBKDF2 (also used as IV in AES encryption)
+    /// sf3 holds the encrypted database key
     sf3: String,
     #[jaded(extract(extract_sf1))]
-    /// sf3 holds the encrypted database key
+    /// sf1 holds the salt of PBKDF2 (also used as IV in AES encryption)
     sf1: String,
 }
 


### PR DESCRIPTION
While reading the decrypted database I noticed that the transaction data from `data.db` is not complete. Also there are more database files within the zip. The next interesting database is `mkabankingapplication.db` which is in my case bigger than `data.db` an contains the newer data, but seems to be missing older data. I have been using my phone for many years now and I am unsure if this splitting will even exists for newer installations. But in any case it is probably a good idea to enable decrypting both database.

This PR adds support for selecting which database will be decrypted via command line flags.

Cheers,
ju6ge